### PR TITLE
fix: go-24403 barcode highlights alignment

### DIFF
--- a/src/utils/highlights.ts
+++ b/src/utils/highlights.ts
@@ -18,7 +18,10 @@ export const computeHighlights = (
     return [];
   }
 
-  let adjustedLayout = layout;
+  let adjustedLayout = {
+    width: layout.height,
+    height: layout.width,
+  };
   if (Platform.OS === 'ios') {
     /* iOS:
      * "portrait" -> "landscape-right"


### PR DESCRIPTION
Updating the adjustedLayout for android to align with the native code.