### PR TITLE
fix: go-24936 rotate the layout for landscape-left only

### DIFF
--- a/src/utils/highlights.ts
+++ b/src/utils/highlights.ts
@@ -30,11 +30,7 @@ export const computeHighlights = (
      * "landscape-right" -> "portrait-upside-down"
      */
     // @NOTE destructure the object to make sure we don't hold a reference to the original layout
-    adjustedLayout = [
-      'landscape-left',
-      'portrait',
-      'portrait-upside-down',
-    ].includes(frame.orientation)
+    adjustedLayout = ['landscape-left'].includes(frame.orientation)
       ? {
           width: layout.height,
           height: layout.width,


### PR DESCRIPTION
Rotate the layout only for landscape-left